### PR TITLE
adding time fields for fr #8

### DIFF
--- a/docs/reference/category.md
+++ b/docs/reference/category.md
@@ -21,8 +21,11 @@ cs_sys_mf | `falcon_device.system_manufacturer` | hp
 cs_sys_name | `falcon_device.system_product_name` | hp_elitebook_850_g7_notebook_pc
 cs_external_ip | `falcon_device.external_ip` | 0.0.0.0
 cs_tags | `falcon_device.tags{}` | n/a
+cs_first_seen | `falcon_device.first_seen` | 02/14/22 09:52:05 MST
+cs_last_seen | `falcon_device.first_seen` | 08/24/22 13:25:24 MDT
+splunk_last_update | n/a | 08/26/22 18:54:42 MDT
 
-Full example of category value
+### Full example of category value
 
 ```text
 cs_agent_version:6.40.15406.0
@@ -41,4 +44,7 @@ cs_os_platform:windows
 cs_sys_mf:hp
 cs_sys_name:hp_elitebook_850_g7_notebook_pc
 cs_uninstallprotection:enabled
+cs_first_seen:02/14/22 09:52:05 MST
+cs_last_seen:08/24/22 13:25:24 MDT
+splunk_last_updated:08/26/22 18:54:42 MDT
 ```

--- a/src/SA-CrowdstrikeDevices/default/savedsearches.conf
+++ b/src/SA-CrowdstrikeDevices/default/savedsearches.conf
@@ -35,6 +35,11 @@ search = `sa_crowdstrike_index` sourcetype="crowdstrike:device:json" \
     "cs_tags:".lower(replace(mvjoin('falcon_device.tags{}', ","),"(?i)FalconGroupingTags/|sensorgroupingtags/", "")),\
     "gen:sa-crowdstrike"\
     ))), "|"), " |-", "_"), "(?:\|[^:]+:[_]+)(\|*)", "\1"),\
+    category=category."|".mvjoin(mvappend(\
+    "cs_first_seen:".strftime(strptime('falcon_device.first_seen',"%FT%T%Z"), "%x %T %Z"),\
+    "cs_last_seen:".strftime(strptime('falcon_device.last_seen',"%FT%T%Z"), "%x %T %Z"),\
+    "splunk_last_updated:".strftime(now(), "%x %T %Z")\
+    ), "|"),\
     nt_host=lower('falcon_device.hostname'),\
     dns=lower(nt_host.".".'falcon_device.machine_domain'),\
     mac=lower(replace('falcon_device.mac_address', "-", ":")),\


### PR DESCRIPTION
Signed-off-by: Zach Christensen <23529374+ZachChristensen28@users.noreply.github.com>

the included change will append the following to the category field:

example value
---
```
cs_first_seen:02/14/22 09:52:05 MST
cs_last_seen:08/24/22 13:25:24 MDT
splunk_last_updated:08/26/22 18:54:42 MDT
```

date is defined as `%x` - The date in the format of the current locale. For example, 7/13/2019 for US English. 
time is defined as `%T %Z`
reference: [Splunk Docs](https://docs.splunk.com/Documentation/Splunk/latest/SearchReference/Commontimeformatvariables)